### PR TITLE
 Fix crawler with base tag

### DIFF
--- a/core/crawl/lib/urlfinder.py
+++ b/core/crawl/lib/urlfinder.py
@@ -15,24 +15,36 @@ from HTMLParser import HTMLParser
 
 
 class UrlFinder:
-	def __init__(self, html):
-		self.html = html
+    def __init__(self, html):
+        self.html = html
 
-	def get_urls(self):
-		urls = []
+    def get_urls(self):
+        urls = []
 
-		class UrlHTMLParser(HTMLParser):			
-			def handle_starttag(self, tag, attrs):
-				if tag == "a":
-					#urls.extend([attr[1] for attr in attrs if attr[0] == "href" and attr[1] != ""])
-					#urls.extend([val for key,val in attrs if key == "href" and val != ""])
-					urls.extend([val for key,val in attrs if key == "href" and (re.match("^https?://", val, re.I) or (not re.match("^[a-z]+:", val, re.I) and not val.startswith("#")))])
-			
-		try:
-			parser = UrlHTMLParser()
-			parser.feed(self.html)
-		except:
-			raise
+        class UrlHTMLParser(HTMLParser):
+            def __init__(self):
+                HTMLParser.__init__(self)
+                self.base_tag_href = ""
 
-		
-		return urls
+            def handle_starttag(self, tag, attrs):
+                # more info about the <base> tag: https://www.w3.org/wiki/HTML/Elements/base
+                if tag == "base":
+                    for key, val in attrs:
+                        if key == "href" and re.match("^https?://", val, re.I):
+                            self.base_tag_href = val.strip()
+
+                elif tag == "a":
+                    for key, val in attrs:
+                        if key == "href":
+                            if re.match("^https?://", val, re.I):
+                                urls.extend([val])
+                            elif not re.match("^[a-z]+:", val, re.I) and not val.startswith("#"):
+                                urls.extend(['{}{}'.format(self.base_tag_href, val)])
+
+        try:
+            parser = UrlHTMLParser()
+            parser.feed(self.html)
+        except:
+            raise
+
+        return urls

--- a/core/crawl/lib/urlfinder.py
+++ b/core/crawl/lib/urlfinder.py
@@ -12,7 +12,7 @@ version.
 
 import re
 from HTMLParser import HTMLParser
-from urlparse import urljoin
+from urlparse import urljoin, urlparse
 
 
 class UrlFinder:
@@ -41,8 +41,8 @@ class UrlHTMLParser(HTMLParser):
         # more info about the <base> tag: https://www.w3.org/wiki/HTML/Elements/base
         if tag == "base":
             for key, val in attrs:
-                if key == "href" and re.match("^https?://", val.strip(), re.I):
-                    self.base_url = val.strip()
+                if key == "href":
+                    self.base_url = urlparse(val.strip()).geturl()
 
         elif tag == "a":
             for key, val in attrs:

--- a/core/crawl/probe/probe.js
+++ b/core/crawl/probe/probe.js
@@ -705,7 +705,7 @@ function initProbe(options, inputValues, userEvents){
 		}
 
 		for(a = 0; a < links.length; a++){
-			var url = links[a].getAttribute('href');
+			var url = links[a].href;
 			if(url){
 				this.printLink(url);
 			}

--- a/tests/crawl/urlfinder_tests.py
+++ b/tests/crawl/urlfinder_tests.py
@@ -1,0 +1,94 @@
+import unittest
+
+from core.crawl.lib.urlfinder import UrlFinder
+
+
+class UrlFinderTest(unittest.TestCase):
+    def test_empty_html(self):
+        html_sample = ""
+        finder = UrlFinder(html_sample)
+
+        self.assertEqual(finder.get_urls(), [])
+
+    def test_basic_html(self):
+        html_sample = """<!DOCTYPE html>
+            <html>
+            <head>
+                <title></title>
+            </head>
+            <body>
+            </body>
+            </html>"""
+        finder = UrlFinder(html_sample)
+
+        self.assertEqual(finder.get_urls(), [])
+
+    def test_with_relative_link(self):
+        html_sample = '<a href="test.html">test</a>'
+        finder = UrlFinder(html_sample)
+
+        self.assertEqual(finder.get_urls(), ["test.html"])
+
+    def test_with_relative_link_and_base_href(self):
+        html_sample = """<!DOCTYPE html>
+            <html>
+            <head>
+                <base href=" http://somewhere.else/someWeirdPath/ " target="_self">
+            </head>
+            <body>
+            <a href="test.html">test</a>
+            </body>
+            </html>"""
+        finder = UrlFinder(html_sample)
+        self.assertEqual(finder.get_urls(), ["http://somewhere.else/someWeirdPath/test.html"])
+
+        html_sample = """<!DOCTYPE html>
+            <html>
+            <head>
+                <base href="http://somewhere.else/someWeirdPath" target="_self">
+            </head>
+            <body>
+            <a href="test.html">test</a>
+            </body>
+            </html>"""
+        finder = UrlFinder(html_sample)
+        self.assertEqual(finder.get_urls(), ["http://somewhere.else/someWeirdPath/test.html"])
+
+        html_sample = """<!DOCTYPE html>
+            <html>
+            <head>
+                <base href="http://somewhere.else/someWeirdPath/index.html" target="_self">
+            </head>
+            <body>
+            <a href="test.html">test</a>
+            </body>
+            </html>"""
+        finder = UrlFinder(html_sample)
+        self.assertEqual(finder.get_urls(), ["http://somewhere.else/someWeirdPath/test.html"])
+
+    def test_with_anchor_link(self):
+        html_sample = '<a href="#test">test</a>'
+        finder = UrlFinder(html_sample)
+
+        self.assertEqual(finder.get_urls(), [])
+
+    def test_with_no_http_link(self):
+        html_sample = '<a href="ftp://test.lan">test</a>'
+
+        finder = UrlFinder(html_sample)
+
+        self.assertEqual(finder.get_urls(), [])
+
+    def test_with_http_absolute_link(self):
+        html_sample = '<a href="http://test.lan">test</a>'
+
+        finder = UrlFinder(html_sample)
+
+        self.assertEqual(finder.get_urls(), ["http://test.lan"])
+
+    def test_with_https_absolute_link(self):
+        html_sample = '<a href="https://test.lan">test</a>'
+
+        finder = UrlFinder(html_sample)
+
+        self.assertEqual(finder.get_urls(), ["https://test.lan"])

--- a/tests/crawl/urlfinder_tests.py
+++ b/tests/crawl/urlfinder_tests.py
@@ -29,7 +29,7 @@ class UrlFinderTest(unittest.TestCase):
 
         self.assertEqual(finder.get_urls(), ["test.html"])
 
-    def test_with_relative_link_and_base_href(self):
+    def test_with_relative_link_and_absolute_base_href(self):
         html_sample = """<!DOCTYPE html>
             <html>
             <head>
@@ -53,6 +53,31 @@ class UrlFinderTest(unittest.TestCase):
             </html>"""
         finder = UrlFinder(html_sample)
         self.assertEqual(finder.get_urls(), ["http://somewhere.else/someWeirdPath/test.html"])
+
+    def test_with_relative_link_and_relative_base_href(self):
+        html_sample = """<!DOCTYPE html>
+            <html>
+            <head>
+                <base href="/someWeirdPath/" target="_self">
+            </head>
+            <body>
+            <a href="test.html">test</a>
+            </body>
+            </html>"""
+        finder = UrlFinder(html_sample)
+        self.assertEqual(finder.get_urls(), ["/someWeirdPath/test.html"])
+
+        html_sample = """<!DOCTYPE html>
+            <html>
+            <head>
+                <base href="someWeirdPath/" target="_self">
+            </head>
+            <body>
+            <a href="test.html">test</a>
+            </body>
+            </html>"""
+        finder = UrlFinder(html_sample)
+        self.assertEqual(finder.get_urls(), ["someWeirdPath/test.html"])
 
     def test_with_anchor_link(self):
         html_sample = '<a href="#test">test</a>'

--- a/tests/crawl/urlfinder_tests.py
+++ b/tests/crawl/urlfinder_tests.py
@@ -45,18 +45,6 @@ class UrlFinderTest(unittest.TestCase):
         html_sample = """<!DOCTYPE html>
             <html>
             <head>
-                <base href="http://somewhere.else/someWeirdPath" target="_self">
-            </head>
-            <body>
-            <a href="test.html">test</a>
-            </body>
-            </html>"""
-        finder = UrlFinder(html_sample)
-        self.assertEqual(finder.get_urls(), ["http://somewhere.else/someWeirdPath/test.html"])
-
-        html_sample = """<!DOCTYPE html>
-            <html>
-            <head>
                 <base href="http://somewhere.else/someWeirdPath/index.html" target="_self">
             </head>
             <body>


### PR DESCRIPTION
Big change are:
- in `core/crawl/lib/urlfinder.py`:
  - retrieving `<base>` href and using `.urljoin()` in `UrlHTMLParser` for link building
  - adding test for `UrlFinder`
- in `core/crawl/probe/probe.js`:
  - using `.href` instead of `.getAttribute('href')` so the href will be interpreted by the browser (applying the `<base>` tag if needed)
