### PR TITLE
Reuse cookies on resume mode

### DIFF
--- a/core/crawl/crawler.py
+++ b/core/crawl/crawler.py
@@ -265,8 +265,8 @@ Options:
             try:
 
                 start_cookies = self._parse_cookie_string(cookie_string)
-                for cookie_string in start_cookies:
-                    Shared.start_cookies.append(Cookie(cookie_string, Shared.start_url))
+                for cookie in start_cookies:
+                    Shared.start_cookies.append(Cookie(cookie, Shared.start_url))
 
             except Exception as e:
                 print("error decoding cookie string: {}".format(str(e)))

--- a/core/crawl/crawler.py
+++ b/core/crawl/crawler.py
@@ -269,8 +269,8 @@ Options:
                 print("error decoding cookie string: {}".format(str(e)))
                 sys.exit(1)
 
-        for sc in start_cookies:
-            Shared.start_cookies.append(Cookie(sc, Shared.start_url))
+        for cookie_string in start_cookies:
+            Shared.start_cookies.append(Cookie(cookie_string, Shared.start_url))
 
         # retrieve start url and output file arguments
         Shared.start_url = normalize_url(args[0])
@@ -301,18 +301,20 @@ Options:
                 target=Shared.start_url,
                 start_date=self.crawl_start_date,
                 commandline=cmd_to_str(argv),
-                user_agent=Shared.options['user_agent']
+                user_agent=Shared.options['user_agent'],
+                start_cookies=Shared.start_cookies
             )
 
             # if the current crawl is not the first one
             if crawl_id > 1:
 
                 # retrieving options from the last crawl
-                random_seed = database.retrieve_crawl_options(crawl_id - 1)
+                random_seed, cookies = database.retrieve_crawl_info(crawl_id - 1)
 
-                # if no cookie were provided and some exist from last crawl
-                # if len(Shared.start_cookies) <= 0 and len(cookies) >= 1:
-                #     pass
+                # if no cookie was provided and some exist from the last crawl
+                if len(Shared.start_cookies) <= 0 and cookies != "[]":
+                    for cookie_string in self._parse_cookie_string(cookies):
+                        Shared.start_cookies.append(Cookie(cookie_string))
 
                 Shared.options["random_seed"] = random_seed
             else:
@@ -420,7 +422,7 @@ Options:
             Shared.requests_index, (self.crawl_end_date - self.crawl_start_date) / 60))
 
         # update end date in db
-        database.update_crawl_info(crawl_id, self.crawl_end_date, Shared.options["random_seed"])
+        database.update_crawl_info(crawl_id, self.crawl_end_date, Shared.options["random_seed"], Shared.end_cookies)
 
     def _main_loop(self, threads, start_requests, database, display_progress=True, verbose=False):
         pending = len(start_requests)

--- a/core/crawl/crawler.py
+++ b/core/crawl/crawler.py
@@ -139,7 +139,6 @@ Options:
         Shared.main_condition = threading.Condition()
 
         # initialize crawl config
-        start_cookies = []
         start_referer = None
 
         threads = []
@@ -264,13 +263,14 @@ Options:
         # initialize cookies
         if cookie_string:
             try:
+
                 start_cookies = self._parse_cookie_string(cookie_string)
+                for cookie_string in start_cookies:
+                    Shared.start_cookies.append(Cookie(cookie_string, Shared.start_url))
+
             except Exception as e:
                 print("error decoding cookie string: {}".format(str(e)))
                 sys.exit(1)
-
-        for cookie_string in start_cookies:
-            Shared.start_cookies.append(Cookie(cookie_string, Shared.start_url))
 
         # retrieve start url and output file arguments
         Shared.start_url = normalize_url(args[0])
@@ -311,12 +311,16 @@ Options:
                 # retrieving options from the last crawl
                 random_seed, cookies = database.retrieve_crawl_info(crawl_id - 1)
 
+                if random_seed:
+                    Shared.options["random_seed"] = random_seed
+                else:
+                    Shared.options["random_seed"] = self._generate_random_string(20)
+
                 # if no cookie was provided and some exist from the last crawl
-                if len(Shared.start_cookies) <= 0 and cookies != "[]":
+                if len(Shared.start_cookies) <= 0 and cookies != "[]" and cookies is not None:
                     for cookie_string in self._parse_cookie_string(cookies):
                         Shared.start_cookies.append(Cookie(cookie_string))
 
-                Shared.options["random_seed"] = random_seed
             else:
                 Shared.options["random_seed"] = self._generate_random_string(20)
 

--- a/core/crawl/crawler_thread.py
+++ b/core/crawl/crawler_thread.py
@@ -193,6 +193,10 @@ class CrawlerThread(threading.Thread):
                     if len(probe.user_output) > 0:
                         request.user_output = probe.user_output
 
+                    # if the probe return some cookies set it has the last one
+                    if probe.cookies:
+                        Shared.end_cookies = probe.cookies
+
             else:
                 errors.append(ERROR_PROBEFAILURE)
                 # get urls with python to continue crawling

--- a/core/crawl/lib/shared.py
+++ b/core/crawl/lib/shared.py
@@ -28,6 +28,7 @@ class Shared:
 
     start_url = ""
     start_cookies = []
+    end_cookies = []
     allowed_domains = set()
     excluded_urls = set()
 

--- a/core/crawl/probe/analyze.js
+++ b/core/crawl/probe/analyze.js
@@ -1,12 +1,12 @@
 /*
-HTCAP - beta 1
-Author: filippo.cavallarin@wearesegment.com
+ HTCAP - beta 1
+ Author: filippo.cavallarin@wearesegment.com
 
-This program is free software; you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free Software
-Foundation; either version 2 of the License, or (at your option) any later
-version.
-*/
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 2 of the License, or (at your option) any later
+ version.
+ */
 
 var system = require('system');
 var fs = require('fs');
@@ -31,42 +31,42 @@ var response = null;
 
 var headers = {};
 
-var args = getopt(system.args,"hVaftUJdICc:MSEp:Tsx:A:r:mHX:PD:R:Oi:u:v");
+var args = getopt(system.args, "hVaftUJdICc:MSEp:Tsx:A:r:mHX:PD:R:Oi:u:v");
 
 var page_settings = {encoding: "utf8"};
 var random = "IsHOulDb34RaNd0MsTR1ngbUt1mN0t";
 var injectScript = null;
 
 
-if(typeof args == 'string'){
-	console.log("Error: " + args);
-	phantom.exit(-1);
+if (typeof args == 'string') {
+    console.log("Error: " + args);
+    phantom.exit(-1);
 }
 
-for(var a = 0; a < args.opts.length; a++){
-	switch(args.opts[a][0]){
-		case "h":
-			usage();
-			phantom.exit(1);
-			break;
-		case "P":
-			page_settings.operation = "POST";
-			break;
-		case "D":
-			page_settings.data = args.opts[a][1];
-			break;
-		case "R":
-			random = args.opts[a][1];
-			break;
-		case "u":
-			injectScript = fs.read(args.opts[a][1]);
-			break;
-		case "v":
-			var vs = verifyUserScript(injectScript);
-			if(vs !== true) console.log(vs);
-			phantom.exit(0);
-			break;
-	}
+for (var a = 0; a < args.opts.length; a++) {
+    switch (args.opts[a][0]) {
+        case "h":
+            usage();
+            phantom.exit(1);
+            break;
+        case "P":
+            page_settings.operation = "POST";
+            break;
+        case "D":
+            page_settings.data = args.opts[a][1];
+            break;
+        case "R":
+            random = args.opts[a][1];
+            break;
+        case "u":
+            injectScript = fs.read(args.opts[a][1]);
+            break;
+        case "v":
+            var vs = verifyUserScript(injectScript);
+            if (vs !== true) console.log(vs);
+            phantom.exit(0);
+            break;
+    }
 }
 
 
@@ -74,228 +74,225 @@ parseArgsToOptions(args);
 
 site = args.args[1];
 
-if(!site){
-	usage();
-	phantom.exit(-1);
+if (!site) {
+    usage();
+    phantom.exit(-1);
 }
 
-if(site.length < 4 || site.substring(0,4).toLowerCase() != "http"){
-	site = "http://" + site;
+if (site.length < 4 || site.substring(0, 4).toLowerCase() != "http") {
+    site = "http://" + site;
 }
 
 console.log("[");
 
 /* maximum execution time */
-setTimeout(execTimedOut,options.maxExecTime);
+setTimeout(execTimedOut, options.maxExecTime);
 
 
-
-phantom.onError = function(msg, trace) {
-  var msgStack = ['PHANTOM ERROR: ' + msg];
-  if (trace && trace.length) {
-    msgStack.push('TRACE:');
-    trace.forEach(function(t) {
-      msgStack.push(' -> ' + (t.file || t.sourceURL) + ': ' + t.line + (t.function ? ' (in function ' + t.function +')' : ''));
-    });
-  }
-  console.error(msgStack.join('\n'));
-  phantom.exit(1);
+phantom.onError = function (msg, trace) {
+    var msgStack = ['PHANTOM ERROR: ' + msg];
+    if (trace && trace.length) {
+        msgStack.push('TRACE:');
+        trace.forEach(function (t) {
+            msgStack.push(' -> ' + (t.file || t.sourceURL) + ': ' + t.line + (t.function ? ' (in function ' + t.function + ')' : ''));
+        });
+    }
+    console.error(msgStack.join('\n'));
+    phantom.exit(1);
 };
 
 
-
-page.onConsoleMessage = function(msg, lineNum, sourceId) {
-	if(options.verbose)
-		console.log("console: " + msg);
+page.onConsoleMessage = function (msg, lineNum, sourceId) {
+    if (options.verbose)
+        console.log("console: " + msg);
 }
-page.onError = function(msg, lineNum, sourceId) {
-	if(options.verbose)
-		console.log("console error: on   " + JSON.stringify(lineNum) + " " + msg);
+page.onError = function (msg, lineNum, sourceId) {
+    if (options.verbose)
+        console.log("console error: on   " + JSON.stringify(lineNum) + " " + msg);
 }
 
-page.onAlert = function(msg) {
-	if(options.verbose)
-  		console.log('ALERT: ' + msg);
+page.onAlert = function (msg) {
+    if (options.verbose)
+        console.log('ALERT: ' + msg);
 };
 
 page.settings.userAgent = options.userAgent;
 page.settings.loadImages = options.loadImages;
 
 
+page.onResourceReceived = function (resource) {
+    if (window.response == null) {
+        window.response = resource;
+        // @TODO sanytize response.contentType
 
-page.onResourceReceived = function(resource) {
-	if(window.response == null){
-		window.response = resource;
-		// @TODO sanytize response.contentType
-
-	}
+    }
 };
 
 
-page.onResourceRequested = function(requestData, networkRequest) {
-	//console.log(JSON.stringify(requestData))
+page.onResourceRequested = function (requestData, networkRequest) {
+    //console.log(JSON.stringify(requestData))
 };
 
 // to detect window.location= / document.location.href=
 page.onNavigationRequested = onNavigationRequested;
 
-page.onConfirm = function(msg) {return true;} // recently changed
+page.onConfirm = function (msg) {
+    return true;
+} // recently changed
 
 /*
  phantomjs issue #11684 workaround
  https://github.com/ariya/phantomjs/issues/11684
  */
 var isPageInitialized = false;
-page.onInitialized = function(){
-	if(isPageInitialized) return;
-	isPageInitialized = true;
+page.onInitialized = function () {
+    if (isPageInitialized) return;
+    isPageInitialized = true;
 
-	// try to hide phantomjs
-	page.evaluate(function(){
-		window.__callPhantom = window.callPhantom;
-		delete window.callPhantom;
-	});
+    // try to hide phantomjs
+    page.evaluate(function () {
+        window.__callPhantom = window.callPhantom;
+        delete window.callPhantom;
+    });
 
-	startProbe(random, injectScript);
+    startProbe(random, injectScript);
 
 };
 
 
-page.onCallback = function(data) {
-	switch(data.cmd){
-		case "print":
-			console.log(data.argument);
-			break;
-		case "log":
-			try{
-				fs.write("htcap_log-" + options.id + ".txt", data.argument + "\n", 'a');
-			} catch(e) {} // @
-			break;
-		case "die": // @TMP
-			console.log(data.argument);
-			phantom.exit(0);
-		case "render":
-			try {
-				page.render(data.argument);
-				return true;
-			} catch(e){
-				return false;
-			}
-			break;
-		case "fwrite":
-			try {
-				fs.write(data.file, data.content, data.mode || 'w');
-				return true;
-			} catch(e) {
-				console.log(e)
-				return false;
-			}
-			break;
-		case "fread":
-			try{
-				return "" + fs.read(data.file);
-			} catch(e){
-				return false;
-			}
-			break;
-		case "end":
+page.onCallback = function (data) {
+    switch (data.cmd) {
+        case "print":
+            console.log(data.argument);
+            break;
+        case "log":
+            try {
+                fs.write("htcap_log-" + options.id + ".txt", data.argument + "\n", 'a');
+            } catch (e) {
+            } // @
+            break;
+        case "die": // @TMP
+            console.log(data.argument);
+            phantom.exit(0);
+        case "render":
+            try {
+                page.render(data.argument);
+                return true;
+            } catch (e) {
+                return false;
+            }
+            break;
+        case "fwrite":
+            try {
+                fs.write(data.file, data.content, data.mode || 'w');
+                return true;
+            } catch (e) {
+                console.log(e)
+                return false;
+            }
+            break;
+        case "fread":
+            try {
+                return "" + fs.read(data.file);
+            } catch (e) {
+                return false;
+            }
+            break;
+        case "end":
 
-			page.evaluate(function () {
-				window.__PROBE__.printRequests();
-			});
+            page.evaluate(function () {
+                window.__PROBE__.printRequests();
+            });
 
-			if(options.returnHtml){
-				page.evaluate(function(options){
-					window.__PROBE__.printPageHTML();
-				}, options);
-			}
+            if (options.returnHtml) {
+                page.evaluate(function (options) {
+                    window.__PROBE__.printPageHTML();
+                }, options);
+            }
 
-			page.evaluate(function () {
-				window.__PROBE__.triggerUserEvent("onEnd");
-			});
+            page.evaluate(function () {
+                window.__PROBE__.triggerUserEvent("onEnd");
+            });
 
-			printStatus("ok", window.response.contentType);
-			phantom.exit(0);
-			break;
+            printStatus("ok", window.response.contentType);
+            phantom.exit(0);
+            break;
 
-	}
+    }
 
 }
 
 
-
-if(options.httpAuth){
-	headers['Authorization'] = 'Basic ' + btoa(options.httpAuth[0] + ":" + options.httpAuth[1]);
+if (options.httpAuth) {
+    headers['Authorization'] = 'Basic ' + btoa(options.httpAuth[0] + ":" + options.httpAuth[1]);
 }
 
-if(options.referer){
-	headers['Referer'] = options.referer;
+if (options.referer) {
+    headers['Referer'] = options.referer;
 }
 
 page.customHeaders = headers;
 
 
-for(var a = 0; a < options.setCookies.length; a++){
-	// maybe this is wrogn acconding to rfc .. but phantomjs cannot set cookie witout a domain...
-	if(!options.setCookies[a].domain){
-		var purl = document.createElement("a");
-		purl.href=site;
-		options.setCookies[a].domain = purl.hostname
-	}
-	if(options.setCookies[a].expires)
-		options.setCookies[a].expires *= 1000;
+for (var a = 0; a < options.setCookies.length; a++) {
+    // maybe this is wrogn acconding to rfc .. but phantomjs cannot set cookie witout a domain...
+    if (!options.setCookies[a].domain) {
+        var purl = document.createElement("a");
+        purl.href = site;
+        options.setCookies[a].domain = purl.hostname
+    }
+    if (options.setCookies[a].expires)
+        options.setCookies[a].expires *= 1000;
 
-	phantom.addCookie(options.setCookies[a]);
+    phantom.addCookie(options.setCookies[a]);
 
 }
 
 page.viewportSize = {
-  width: 1920,
-  height: 1080
+    width: 1920,
+    height: 1080
 };
 
 
+page.open(site, page_settings, function (status) {
+    var response = window.response; // just to be clear
+    if (status !== 'success') {
+        var mess = "";
+        var out = {response: response};
+        if (!response || response.headers.length == 0) {
+            printStatus("error", "load");
+            phantom.exit(1);
+        }
+
+        // check for redirect first
+        for (var a = 0; a < response.headers.length; a++) {
+            if (response.headers[a].name.toLowerCase() == 'location') {
+
+                if (options.getCookies) {
+                    printCookies();
+                }
+                printStatus("ok", null, null, response.headers[a].value);
+                phantom.exit(0);
+            }
+        }
+
+        assertContentTypeHtml(response);
+
+        phantom.exit(1);
+    }
 
 
-page.open(site, page_settings, function(status) {
-	var response = window.response; // just to be clear
-	if (status !== 'success'){
-		var mess = "";
-		var out = {response: response};
-		if(!response || response.headers.length == 0){
-			printStatus("error", "load");
-			phantom.exit(1);
-		}
+    if (options.getCookies) {
+        printCookies();
+    }
 
-		// check for redirect first
-		for(var a = 0; a < response.headers.length; a++){
-			if(response.headers[a].name.toLowerCase() == 'location'){
+    assertContentTypeHtml(response);
 
-				if(options.getCookies){
-					printCookies(response.headers, site);
-				}
-				printStatus("ok", null, null, response.headers[a].value);
-				phantom.exit(0);
-			}
-		}
-
-		assertContentTypeHtml(response);
-
-		phantom.exit(1);
-	}
-
-
-	if(options.getCookies){
-		printCookies(response.headers, site);
-	}
-
-	assertContentTypeHtml(response);
-
-	page.evaluate(function(){
-		console.log("startAnalysis");
-		// starting page analysis
-		window.__PROBE__.startAnalysis();
-	})
+    page.evaluate(function () {
+        console.log("startAnalysis");
+        // starting page analysis
+        window.__PROBE__.startAnalysis();
+    })
 
 
 });

--- a/core/crawl/probe/functions.js
+++ b/core/crawl/probe/functions.js
@@ -1,627 +1,569 @@
 /*
-HTCAP - beta 1
-Author: filippo.cavallarin@wearesegment.com
+ HTCAP - beta 1
+ Author: filippo.cavallarin@wearesegment.com
 
-This program is free software; you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free Software
-Foundation; either version 2 of the License, or (at your option) any later
-version.
-*/
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 2 of the License, or (at your option) any later
+ version.
+ */
 
 // @todo error on Unknown option ds
-function getopt(arguments, optstring){
-	var args = arguments.slice();
-	var ret = {
-		opts: [],
-		args: args
-	};
+function getopt(arguments, optstring) {
+    var args = arguments.slice();
+    var ret = {
+        opts: [],
+        args: args
+    };
 
-	var m = optstring.match(/[a-zA-Z]\:*/g);
-	for(var a = 0; a < m.length; a++){
-		var ai = args.indexOf("-" + m[a][0]);
-		if(ai > -1){
-			if(m[a][1] == ":"){
-				if(args[ai+1]){
-					ret.opts.push([m[a][0], args[ai+1]]);
-					args.splice(ai,2);
-				} else {
-					return "missing argumnet for option " + m[a][0];
-				}
-			} else {
-				ret.opts.push([m[a][0]]);
-				args.splice(ai,1);
-			}
-		}
-	}
+    var m = optstring.match(/[a-zA-Z]\:*/g);
+    for (var a = 0; a < m.length; a++) {
+        var ai = args.indexOf("-" + m[a][0]);
+        if (ai > -1) {
+            if (m[a][1] == ":") {
+                if (args[ai + 1]) {
+                    ret.opts.push([m[a][0], args[ai + 1]]);
+                    args.splice(ai, 2);
+                } else {
+                    return "missing argumnet for option " + m[a][0];
+                }
+            } else {
+                ret.opts.push([m[a][0]]);
+                args.splice(ai, 1);
+            }
+        }
+    }
 
-	return ret;
+    return ret;
 }
 
 
-function removeHash(url){
-	var anchor = document.createElement("a");
-	anchor.href = url;
+function removeHash(url) {
+    var anchor = document.createElement("a");
+    anchor.href = url;
 
-	return anchor.protocol + "//" + anchor.host + anchor.pathname + anchor.search;
+    return anchor.protocol + "//" + anchor.host + anchor.pathname + anchor.search;
 }
 
 
+function compareUrls(url1, url2, includeHash) {
+    var a1 = document.createElement("a");
+    var a2 = document.createElement("a");
+    a1.href = url1;
+    a2.href = url2;
 
-function compareUrls(url1, url2, includeHash){
-	var a1 = document.createElement("a");
-	var a2 = document.createElement("a");
-	a1.href = url1;
-	a2.href = url2;
+    var eq = (a1.protocol == a2.protocol && a1.host == a2.host && a1.pathname == a2.pathname && a1.search == a2.search);
 
-	var eq = (a1.protocol == a2.protocol && a1.host == a2.host && a1.pathname == a2.pathname && a1.search == a2.search);
+    if (includeHash) eq = eq && a1.hash == a2.hash;
 
-	if(includeHash) eq = eq && a1.hash == a2.hash;
-
-	return eq;
-
-}
-
-
-function printCookies(headers, site){
-	var cookies = getCookies(headers, site);
-	console.log('["cookies",' + JSON.stringify(cookies) + "],");
-}
-
-
-function printStatus(status, errcode, message, redirect){
-	var o = {status:status};
-	if(status == "error"){
-		o.code = errcode;
-		switch(errcode){
-			case "load":
-				break;
-			case "contentType":
-				o.message = message;
-				break;
-			case "requestTimeout":
-				break;
-			case "probe_timeout":
-				break;
-		}
-	}
-	if(redirect) o.redirect = redirect;
-	o.time = Math.floor((Date.now() - window.startTime)/1000);
-	console.log(JSON.stringify(o));
-	console.log("]")
-}
-
-
-
-function execTimedOut(){
-	if(!response || response.headers.length == 0){
-		printStatus("error", "requestTimeout");
-		phantom.exit(0);
-	}
-	printStatus("error", "probe_timeout");
-	phantom.exit(0);
+    return eq;
 
 }
 
 
-
-function usage(){
-	var usage = "Usage: analyze.js [options] <url>\n" +
-				"  -V              verbose\n" +
-				"  -a              don't check ajax\n" +
-				"  -f              don't fill values\n" +
-				"  -t              don't trigger events (onload only)\n" +
-				"  -s              don't check websockets\n" +
-				"  -M              dont' map events\n" +
-				"  -T              don't trigger mapped events\n" +
-				"  -S              don't check for <script> insertion\n" +
-				"  -P              load page with POST\n" +
-				"  -D              POST data\n" +
-				"  -R <string>     random string used to generate random values - the same random string will generate the same random values\n" +
-				"  -X              comma separated list of excluded urls\n" +
-				"  -C              don't get cookies\n" +
-				"  -c <path>       set cookies from file (json)\n" +
-				"  -p <user:pass>  http auth \n" +
-				"  -x <seconds>    maximum execution time \n" +
-				"  -A <user agent> set user agent \n" +
-				"  -r <url>        set referer \n" +
-				"  -H              return generated html \n" +
-				"  -I              load images\n" + 
-				"  -O              dont't override timeout functions\n" +
-				"  -u              path to user script to inject\n" +
-				"  -K              keep elements in the DOM (prevent removal)\n" +
-				"  -v              verify user script and exit";
-	console.log(usage);
+function printCookies() {
+    console.log('["cookies",' + JSON.stringify(phantom.cookies) + "],");
 }
 
 
+function printStatus(status, errcode, message, redirect) {
+    var o = {status: status};
+    if (status == "error") {
+        o.code = errcode;
+        switch (errcode) {
+            case "load":
+                break;
+            case "contentType":
+                o.message = message;
+                break;
+            case "requestTimeout":
+                break;
+            case "probe_timeout":
+                break;
+        }
+    }
+    if (redirect) o.redirect = redirect;
+    o.time = Math.floor((Date.now() - window.startTime) / 1000);
+    console.log(JSON.stringify(o));
+    console.log("]")
+}
 
-function parseArgsToOptions(args){
 
-	for(var a = 0; a < args.opts.length; a++){
-		switch(args.opts[a][0]){
-			// case "h":
-			// 	//showHelp = true;
-			// 	usage();
-			// 	phantom.exit(1);
-			// 	break;
-			case "V":
-				options.verbose = true;
-				break;
-			case "a":
-				options.checkAjax = false;
-				break;
-			case "f":
-				options.fillValues = false;
-				break;
-			case "t":
-				options.triggerEvents = false;
-				break;
-			case "d":
-				options.printAjaxPostData = false;
-			case "S":
-				options.checkScriptInsertion = false;
-				break;
-			case "I":
-				options.loadImages = true;
-				break;
-			case "C":
-				options.getCookies = false;
-				break;
+function execTimedOut() {
+    if (!response || response.headers.length == 0) {
+        printStatus("error", "requestTimeout");
+        phantom.exit(0);
+    }
+    printStatus("error", "probe_timeout");
+    phantom.exit(0);
 
-			case "c":
-				try{
-					var cookie_file = fs.read(args.opts[a][1]);
-					options.setCookies = JSON.parse(cookie_file);
-				} catch(e){
-					console.log(e);
-					phantom.exit(1);
-				}
+}
 
-				break;
-			case "p":
-				var arr = args.opts[a][1].split(":");
-				options.httpAuth = [arr[0], arr.slice(1).join(":")];
-				break;
-			case "M":
-				options.mapEvents = false;
-				break;
-			case "T":
-				options.triggerAllMappedEvents = false;
-				break;
-			case "s":
-				options.checkWebsockets = false;
-				break;
-			case "x":
-				options.maxExecTime = parseInt(args.opts[a][1]) * 1000;
-				break;
-			case "A":
-				options.userAgent = args.opts[a][1];
-				break;
-			case "r":
-				options.referer = args.opts[a][1];
-				break;
-			case "m":
-				options.outputMappedEvents = true;
-				break;
-			case "H":
-				options.returnHtml = true;
-				break;
-			case "X":
-				options.excludedUrls = args.opts[a][1].split(",");
-				break;
-			case "O":
-				options.overrideTimeoutFunctions = false;
-				break;
-			case "O":
-				options.overrideTimeoutFunctions = false;
-				break;
-			case "i":
-				options.id = args.opts[a][1];
-				break;
-			case "K":
-				options.preventElementRemoval = true;
-				break;
-		}
-	}
+
+function usage() {
+    var usage = "Usage: analyze.js [options] <url>\n" +
+        "  -V              verbose\n" +
+        "  -a              don't check ajax\n" +
+        "  -f              don't fill values\n" +
+        "  -t              don't trigger events (onload only)\n" +
+        "  -s              don't check websockets\n" +
+        "  -M              dont' map events\n" +
+        "  -T              don't trigger mapped events\n" +
+        "  -S              don't check for <script> insertion\n" +
+        "  -P              load page with POST\n" +
+        "  -D              POST data\n" +
+        "  -R <string>     random string used to generate random values - the same random string will generate the same random values\n" +
+        "  -X              comma separated list of excluded urls\n" +
+        "  -C              don't get cookies\n" +
+        "  -c <path>       set cookies from file (json)\n" +
+        "  -p <user:pass>  http auth \n" +
+        "  -x <seconds>    maximum execution time \n" +
+        "  -A <user agent> set user agent \n" +
+        "  -r <url>        set referer \n" +
+        "  -H              return generated html \n" +
+        "  -I              load images\n" +
+        "  -O              dont't override timeout functions\n" +
+        "  -u              path to user script to inject\n" +
+        "  -K              keep elements in the DOM (prevent removal)\n" +
+        "  -v              verify user script and exit";
+    console.log(usage);
+}
+
+
+function parseArgsToOptions(args) {
+
+    for (var a = 0; a < args.opts.length; a++) {
+        switch (args.opts[a][0]) {
+            // case "h":
+            // 	//showHelp = true;
+            // 	usage();
+            // 	phantom.exit(1);
+            // 	break;
+            case "V":
+                options.verbose = true;
+                break;
+            case "a":
+                options.checkAjax = false;
+                break;
+            case "f":
+                options.fillValues = false;
+                break;
+            case "t":
+                options.triggerEvents = false;
+                break;
+            case "d":
+                options.printAjaxPostData = false;
+            case "S":
+                options.checkScriptInsertion = false;
+                break;
+            case "I":
+                options.loadImages = true;
+                break;
+            case "C":
+                options.getCookies = false;
+                break;
+
+            case "c":
+                try {
+                    var cookie_file = fs.read(args.opts[a][1]);
+                    options.setCookies = JSON.parse(cookie_file);
+                } catch (e) {
+                    console.log(e);
+                    phantom.exit(1);
+                }
+
+                break;
+            case "p":
+                var arr = args.opts[a][1].split(":");
+                options.httpAuth = [arr[0], arr.slice(1).join(":")];
+                break;
+            case "M":
+                options.mapEvents = false;
+                break;
+            case "T":
+                options.triggerAllMappedEvents = false;
+                break;
+            case "s":
+                options.checkWebsockets = false;
+                break;
+            case "x":
+                options.maxExecTime = parseInt(args.opts[a][1]) * 1000;
+                break;
+            case "A":
+                options.userAgent = args.opts[a][1];
+                break;
+            case "r":
+                options.referer = args.opts[a][1];
+                break;
+            case "m":
+                options.outputMappedEvents = true;
+                break;
+            case "H":
+                options.returnHtml = true;
+                break;
+            case "X":
+                options.excludedUrls = args.opts[a][1].split(",");
+                break;
+            case "O":
+                options.overrideTimeoutFunctions = false;
+                break;
+            case "O":
+                options.overrideTimeoutFunctions = false;
+                break;
+            case "i":
+                options.id = args.opts[a][1];
+                break;
+            case "K":
+                options.preventElementRemoval = true;
+                break;
+        }
+    }
 };
 
 function onNavigationRequested(url, type) {
 
-	if (page.navigationLocked === true) {
-		page.evaluate(function (url, type) {
-			if (type === "LinkClicked")
-				return;
+    if (page.navigationLocked === true) {
+        page.evaluate(function (url, type) {
+            if (type === "LinkClicked")
+                return;
 
-			if (type === 'Other' && url !== "about:blank") {
-				window.__PROBE__.printLink(url);
-			}
+            if (type === 'Other' && url !== "about:blank") {
+                window.__PROBE__.printLink(url);
+            }
 
-		}, url, type);
-	}
+        }, url, type);
+    }
 
 
-	// allow the navigation if only the hash is changed
-	if (page.navigationLocked === true && compareUrls(url, site)) {
-		page.navigationLocked = false;
-		page.evaluate(function(url){
-			document.location.href=url;
-		},url);
-	}
+    // allow the navigation if only the hash is changed
+    if (page.navigationLocked === true && compareUrls(url, site)) {
+        page.navigationLocked = false;
+        page.evaluate(function (url) {
+            document.location.href = url;
+        }, url);
+    }
 
-	page.navigationLocked = true;
+    page.navigationLocked = true;
 }
 
 
 // generates PSEUDO random values. the same seed will generate the same values
-function generateRandomValues(seed){
-	var values = {};
-	var letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-	var numbers = "0123456789";
-	var symbols = "!#&^;.,?%$*";
-	var months = ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"];
-	var years = ["1982", "1989", "1990", "1994", "1995", "1996"];
-	var names = ["james", "john", "robert", "michael", "william", "david", "richard", "charles", "joseph", "thomas", "christopher", "daniel", "paul", "mark", "donald", "george", "kenneth"];
-	var surnames = ["anderson", "thomas", "jackson", "white", "harris", "martin", "thompson", "garcia", "martinez", "robinson", "clark", "rodriguez", "lewis", "lee", "walker", "hall"];
-	var domains = [".com", ".org", ".net", ".it", ".tv", ".de", ".fr"];
+function generateRandomValues(seed) {
+    var values = {};
+    var letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    var numbers = "0123456789";
+    var symbols = "!#&^;.,?%$*";
+    var months = ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"];
+    var years = ["1982", "1989", "1990", "1994", "1995", "1996"];
+    var names = ["james", "john", "robert", "michael", "william", "david", "richard", "charles", "joseph", "thomas", "christopher", "daniel", "paul", "mark", "donald", "george", "kenneth"];
+    var surnames = ["anderson", "thomas", "jackson", "white", "harris", "martin", "thompson", "garcia", "martinez", "robinson", "clark", "rodriguez", "lewis", "lee", "walker", "hall"];
+    var domains = [".com", ".org", ".net", ".it", ".tv", ".de", ".fr"];
 
-	var randoms = [];
-	var randoms_i = 0;
+    var randoms = [];
+    var randoms_i = 0;
 
-	for(var a = 0; a < seed.length; a++){
-		var i = seed[a].charCodeAt(0);
-		randoms.push(i);
-	}
+    for (var a = 0; a < seed.length; a++) {
+        var i = seed[a].charCodeAt(0);
+        randoms.push(i);
+    }
 
-	var rand = function(max){
-		var i = randoms[randoms_i] % max;
-		randoms_i = (randoms_i + 1) % randoms.length;
-		return i;
-	}
+    var rand = function (max) {
+        var i = randoms[randoms_i] % max;
+        randoms_i = (randoms_i + 1) % randoms.length;
+        return i;
+    }
 
-	var randarr = function(arr, len){
-		var r;
-		var ret = "";
-		for(var a = 0; a < len; a++){
-			r = rand(arr.length - 1) ;
-			ret += arr[r];
-		}
-		return ret;
-	};
+    var randarr = function (arr, len) {
+        var r;
+        var ret = "";
+        for (var a = 0; a < len; a++) {
+            r = rand(arr.length - 1);
+            ret += arr[r];
+        }
+        return ret;
+    };
 
-	var generators = {
-		string: function(){
-			return randarr(letters, 8);
-		},
-		number: function(){
-			return randarr(numbers, 3);
-		},
-		month: function(){
-			return randarr(months, 1);
-		},
-		year: function(){
-			return randarr(years, 1);
-		},
-		date: function(){
-			return generators.year() + "-" + generators.month() + "-" + generators.month();
-		},
-		color: function(){
-			return "#" + randarr(numbers, 6);
-		},
-		week: function(){
-			return generators.year() + "-W" + randarr(months.slice(0, 6), 1);
-		},
-		time: function(){
-			return generators.month() + ":" + generators.month();
-		},
-		datetimeLocal: function(){
-			return generators.date() + "T" + generators.time();
-		},
-		domain: function(){
-			return randarr(letters, 12).toLowerCase() + randarr(domains ,1);
-		},
-		email: function(){
-			return randarr(names, 1) + "." + generators.surname() + "@" + generators.domain();
-		},
-		url: function(){
-			return "http://www." + generators.domain();
-		},
-		humandate: function(){
-			return  generators.month() + "/" + generators.month() + "/" + generators.year();
-		},
-		password: function(){
-			return randarr(letters, 3) + randarr(symbols, 1) + randarr(letters, 2) + randarr(numbers, 3) + randarr(symbols, 2);
-		},
-		surname: function(){
-			return randarr(surnames, 1);
-		},
-		lastname: function(){
-			return generators.surname();
-		},
-		firstname: function(){
-			return randarr(names, 1);
-		},
-		tel: function(){
-			return "+" + randarr(numbers, 1) + " " + randarr(numbers, 10)
-		}
-	};
+    var generators = {
+        string: function () {
+            return randarr(letters, 8);
+        },
+        number: function () {
+            return randarr(numbers, 3);
+        },
+        month: function () {
+            return randarr(months, 1);
+        },
+        year: function () {
+            return randarr(years, 1);
+        },
+        date: function () {
+            return generators.year() + "-" + generators.month() + "-" + generators.month();
+        },
+        color: function () {
+            return "#" + randarr(numbers, 6);
+        },
+        week: function () {
+            return generators.year() + "-W" + randarr(months.slice(0, 6), 1);
+        },
+        time: function () {
+            return generators.month() + ":" + generators.month();
+        },
+        datetimeLocal: function () {
+            return generators.date() + "T" + generators.time();
+        },
+        domain: function () {
+            return randarr(letters, 12).toLowerCase() + randarr(domains, 1);
+        },
+        email: function () {
+            return randarr(names, 1) + "." + generators.surname() + "@" + generators.domain();
+        },
+        url: function () {
+            return "http://www." + generators.domain();
+        },
+        humandate: function () {
+            return generators.month() + "/" + generators.month() + "/" + generators.year();
+        },
+        password: function () {
+            return randarr(letters, 3) + randarr(symbols, 1) + randarr(letters, 2) + randarr(numbers, 3) + randarr(symbols, 2);
+        },
+        surname: function () {
+            return randarr(surnames, 1);
+        },
+        lastname: function () {
+            return generators.surname();
+        },
+        firstname: function () {
+            return randarr(names, 1);
+        },
+        tel: function () {
+            return "+" + randarr(numbers, 1) + " " + randarr(numbers, 10)
+        }
+    };
 
 
-	for(var type in generators){
-		values[type] = generators[type]();
-	}
+    for (var type in generators) {
+        values[type] = generators[type]();
+    }
 
-	return values;
+    return values;
 
 
 };
-
-
-
-
-
 
 
 function startProbe(random, injectScript) {
-	// generate a static map of random values using a "static" seed for input fields
-	// the same seed generates the same values
-	// generated values MUST be the same for all analyze.js call othewise the same form will look different
-	// for example if a page sends a form to itself with input=random1,
-	// the same form on the same page (after first post) will became input=random2
-	// => form.data1 != form.data2 => form.data2 is considered a different request and it'll be crawled.
-	// this process will lead to and infinite loop!
-	var inputValues = generateRandomValues(random);
+    // generate a static map of random values using a "static" seed for input fields
+    // the same seed generates the same values
+    // generated values MUST be the same for all analyze.js call othewise the same form will look different
+    // for example if a page sends a form to itself with input=random1,
+    // the same form on the same page (after first post) will became input=random2
+    // => form.data1 != form.data2 => form.data2 is considered a different request and it'll be crawled.
+    // this process will lead to and infinite loop!
+    var inputValues = generateRandomValues(random);
 
-	// adding constants to page
-	page.evaluate(function (__HTCAP) {
-		window.__HTCAP = __HTCAP;
-	}, window.__HTCAP);
+    // adding constants to page
+    page.evaluate(function (__HTCAP) {
+        window.__HTCAP = __HTCAP;
+    }, window.__HTCAP);
 
-	page.evaluate(initProbe, options, inputValues, injectScript);
+    page.evaluate(initProbe, options, inputValues, injectScript);
 
-	page.evaluate(function(options) {
+    page.evaluate(function (options) {
 
-		if(options.mapEvents){
+        if (options.mapEvents) {
 
-			Node.prototype.__originalAddEventListener = Node.prototype.addEventListener;
-			Node.prototype.addEventListener = function () {
-				if (arguments[0] !== "DOMContentLoaded") { // is this ok???
-					window.__PROBE__.addEventToMap(this, arguments[0]);
-				}
-				this.__originalAddEventListener.apply(this, arguments);
-			};
+            Node.prototype.__originalAddEventListener = Node.prototype.addEventListener;
+            Node.prototype.addEventListener = function () {
+                if (arguments[0] !== "DOMContentLoaded") { // is this ok???
+                    window.__PROBE__.addEventToMap(this, arguments[0]);
+                }
+                this.__originalAddEventListener.apply(this, arguments);
+            };
 
-			window.__originalAddEventListener = window.addEventListener;
-			window.addEventListener = function () {
-				if (arguments[0] !== "load") { // is this ok???
-					window.__PROBE__.addEventToMap(this, arguments[0]);
-				}
-				window.__originalAddEventListener.apply(this, arguments);
-			};
-		}
+            window.__originalAddEventListener = window.addEventListener;
+            window.addEventListener = function () {
+                if (arguments[0] !== "load") { // is this ok???
+                    window.__PROBE__.addEventToMap(this, arguments[0]);
+                }
+                window.__originalAddEventListener.apply(this, arguments);
+            };
+        }
 
-		if(options.checkAjax){
-			XMLHttpRequest.prototype.__originalOpen = XMLHttpRequest.prototype.open;
-			XMLHttpRequest.prototype.open = function(method, url, async, user, password){
+        if (options.checkAjax) {
+            XMLHttpRequest.prototype.__originalOpen = XMLHttpRequest.prototype.open;
+            XMLHttpRequest.prototype.open = function (method, url, async, user, password) {
 
-				var _url = window.__PROBE__.removeUrlParameter(url, "_");
-				this.__request = new window.__PROBE__.Request("xhr", method, _url);
+                var _url = window.__PROBE__.removeUrlParameter(url, "_");
+                this.__request = new window.__PROBE__.Request("xhr", method, _url);
 
-				// adding XHR listener
-				this.addEventListener('readystatechange', function () {
-					// if not finish, it's open
-					// https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState
-					if (this.readyState >= 1 && this.readyState < 4) {
-						window.__PROBE__.eventLoopManager.sentXHR(this);
-					} else if (this.readyState === 4) {
-						// /!\ DONE means that the XHR finish but could have FAILED
-						window.__PROBE__.eventLoopManager.doneXHR(this);
-					}
-				});
-				this.addEventListener('error', function () {
-					window.__PROBE__.eventLoopManager.inErrorXHR(this);
-				});
-				this.addEventListener('abort', function () {
-					window.__PROBE__.eventLoopManager.inErrorXHR(this);
-				});
-				this.addEventListener('timeout', function () {
-					window.__PROBE__.eventLoopManager.inErrorXHR(this);
-				});
+                // adding XHR listener
+                this.addEventListener('readystatechange', function () {
+                    // if not finish, it's open
+                    // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState
+                    if (this.readyState >= 1 && this.readyState < 4) {
+                        window.__PROBE__.eventLoopManager.sentXHR(this);
+                    } else if (this.readyState === 4) {
+                        // /!\ DONE means that the XHR finish but could have FAILED
+                        window.__PROBE__.eventLoopManager.doneXHR(this);
+                    }
+                });
+                this.addEventListener('error', function () {
+                    window.__PROBE__.eventLoopManager.inErrorXHR(this);
+                });
+                this.addEventListener('abort', function () {
+                    window.__PROBE__.eventLoopManager.inErrorXHR(this);
+                });
+                this.addEventListener('timeout', function () {
+                    window.__PROBE__.eventLoopManager.inErrorXHR(this);
+                });
 
-				this.timeout = options.XHRTimeout;
+                this.timeout = options.XHRTimeout;
 
-				return this.__originalOpen(method, url, async, user, password);
-			};
+                return this.__originalOpen(method, url, async, user, password);
+            };
 
-			XMLHttpRequest.prototype.__originalSend = XMLHttpRequest.prototype.send;
-			XMLHttpRequest.prototype.send = function(data){
-				this.__request.data = data;
-				this.__request.triggerer = window.__PROBE__.getLastTriggerPageEvent();
+            XMLHttpRequest.prototype.__originalSend = XMLHttpRequest.prototype.send;
+            XMLHttpRequest.prototype.send = function (data) {
+                this.__request.data = data;
+                this.__request.triggerer = window.__PROBE__.getLastTriggerPageEvent();
 
-				var absurl = window.__PROBE__.getAbsoluteUrl(this.__request.url);
-				for(var a = 0; a < options.excludedUrls.length; a++){
-					if(absurl.match(options.excludedUrls[a])){
-						this.__skipped = true;
-					}
-				}
+                var absurl = window.__PROBE__.getAbsoluteUrl(this.__request.url);
+                for (var a = 0; a < options.excludedUrls.length; a++) {
+                    if (absurl.match(options.excludedUrls[a])) {
+                        this.__skipped = true;
+                    }
+                }
 
-				// check if request has already been sent
-				var requestKey = this.__request.key;
-				if (window.__PROBE__.sentXHRs.indexOf(requestKey) !== -1) {
-					return;
-				}
+                // check if request has already been sent
+                var requestKey = this.__request.key;
+                if (window.__PROBE__.sentXHRs.indexOf(requestKey) !== -1) {
+                    return;
+                }
 
-				var ueRet = window.__PROBE__.triggerUserEvent("onXhr",[this.__request]);
-				if(ueRet){
-					window.__PROBE__.sentXHRs.push(requestKey);
-					window.__PROBE__.addToRequestToPrint(this.__request);
+                var ueRet = window.__PROBE__.triggerUserEvent("onXhr", [this.__request]);
+                if (ueRet) {
+                    window.__PROBE__.sentXHRs.push(requestKey);
+                    window.__PROBE__.addToRequestToPrint(this.__request);
 
-					if(!this.__skipped)
-						return this.__originalSend(data);
-				}
-			};
-		}
+                    if (!this.__skipped)
+                        return this.__originalSend(data);
+                }
+            };
+        }
 
-		if(options.checkScriptInsertion){
+        if (options.checkScriptInsertion) {
 
-			Node.prototype.__originalAppendChild = Node.prototype.appendChild;
-			Node.prototype.appendChild = function(node){
-				window.__PROBE__.printJSONP(node);
-				return this.__originalAppendChild(node);
-			}
+            Node.prototype.__originalAppendChild = Node.prototype.appendChild;
+            Node.prototype.appendChild = function (node) {
+                window.__PROBE__.printJSONP(node);
+                return this.__originalAppendChild(node);
+            }
 
-			Node.prototype.__originalInsertBefore = Node.prototype.insertBefore;
-			Node.prototype.insertBefore = function(node, element){
-				window.__PROBE__.printJSONP(node);
-				return this.__originalInsertBefore(node, element);
-			}
+            Node.prototype.__originalInsertBefore = Node.prototype.insertBefore;
+            Node.prototype.insertBefore = function (node, element) {
+                window.__PROBE__.printJSONP(node);
+                return this.__originalInsertBefore(node, element);
+            }
 
-			Node.prototype.__originalReplaceChild = Node.prototype.replaceChild;
-			Node.prototype.replaceChild = function(node, oldNode){
-				window.__PROBE__.printJSONP(node);
-				return this.__originalReplaceChild(node, oldNode);
-			}
-		}
+            Node.prototype.__originalReplaceChild = Node.prototype.replaceChild;
+            Node.prototype.replaceChild = function (node, oldNode) {
+                window.__PROBE__.printJSONP(node);
+                return this.__originalReplaceChild(node, oldNode);
+            }
+        }
 
-		if(options.checkWebsockets){
-			window.WebSocket = (function(WebSocket){
-				return function(url, protocols){
-					window.__PROBE__.printWebsocket(url); //websockets.push(url);
-					return WebSocket.prototype;
-				}
-			})(window.WebSocket);
-		}
+        if (options.checkWebsockets) {
+            window.WebSocket = (function (WebSocket) {
+                return function (url, protocols) {
+                    window.__PROBE__.printWebsocket(url); //websockets.push(url);
+                    return WebSocket.prototype;
+                }
+            })(window.WebSocket);
+        }
 
-		if(options.overrideTimeoutFunctions){
-			window.__originalSetTimeout = window.setTimeout;
-			window.setTimeout = function () {
-				// Forcing a delay of 0
-				arguments[1] = 0;
-				return window.__originalSetTimeout.apply(this, arguments);
-			};
+        if (options.overrideTimeoutFunctions) {
+            window.__originalSetTimeout = window.setTimeout;
+            window.setTimeout = function () {
+                // Forcing a delay of 0
+                arguments[1] = 0;
+                return window.__originalSetTimeout.apply(this, arguments);
+            };
 
-			window.__originalSetInterval = window.setInterval;
-			window.setInterval = function () {
-				// Forcing a delay of 0
-				arguments[1] = 0;
-				return window.__originalSetInterval.apply(this, arguments);
-			};
+            window.__originalSetInterval = window.setInterval;
+            window.setInterval = function () {
+                // Forcing a delay of 0
+                arguments[1] = 0;
+                return window.__originalSetInterval.apply(this, arguments);
+            };
 
-		}
+        }
 
-		if(options.preventElementRemoval){
-			Node.prototype.__originalRemoveChild = Node.prototype.removeChild;
-			Node.prototype.removeChild = function(node){
-				return node;
-			}
-		}
+        if (options.preventElementRemoval) {
+            Node.prototype.__originalRemoveChild = Node.prototype.removeChild;
+            Node.prototype.removeChild = function (node) {
+                return node;
+            }
+        }
 
-		HTMLFormElement.prototype.__originalSubmit = HTMLFormElement.prototype.submit;
-		HTMLFormElement.prototype.submit = function(){
-			window.__PROBE__.addToRequestToPrint(window.__PROBE__.getFormAsRequest(this));
-			return this.__originalSubmit();
-		};
+        HTMLFormElement.prototype.__originalSubmit = HTMLFormElement.prototype.submit;
+        HTMLFormElement.prototype.submit = function () {
+            window.__PROBE__.addToRequestToPrint(window.__PROBE__.getFormAsRequest(this));
+            return this.__originalSubmit();
+        };
 
-		// prevent window.close
-		window.close = function () {
-		};
+        // prevent window.close
+        window.close = function () {
+        };
 
-		window.open = function(url, name, specs, replace){
-			window.__PROBE__.printLink(url);
-		};
+        window.open = function (url, name, specs, replace) {
+            window.__PROBE__.printLink(url);
+        };
 
-		// create an observer instance for DOM changes
-		var observer = new WebKitMutationObserver(function (mutations) {
-			window.__PROBE__.eventLoopManager.nodeMutated(mutations);
-		});
-		var eventAttributeList = ['src', 'href'];
-		window.__HTCAP.mappableEvents.forEach(function (event) {
-			eventAttributeList.push('on' + event);
-		});
-		// observing for any change on document and its children
-		observer.observe(document.documentElement, {
-			childList: true,
-			attributes: true,
-			characterData: false,
-			subtree: true,
-			attributeOldValue: true,
-			characterDataOldValue: false,
-			attributeFilter: eventAttributeList
-		});
+        // create an observer instance for DOM changes
+        var observer = new WebKitMutationObserver(function (mutations) {
+            window.__PROBE__.eventLoopManager.nodeMutated(mutations);
+        });
+        var eventAttributeList = ['src', 'href'];
+        window.__HTCAP.mappableEvents.forEach(function (event) {
+            eventAttributeList.push('on' + event);
+        });
+        // observing for any change on document and its children
+        observer.observe(document.documentElement, {
+            childList: true,
+            attributes: true,
+            characterData: false,
+            subtree: true,
+            attributeOldValue: true,
+            characterDataOldValue: false,
+            attributeFilter: eventAttributeList
+        });
 
-		window.__PROBE__.triggerUserEvent("onInit");
-	}, options);
+        window.__PROBE__.triggerUserEvent("onInit");
+    }, options);
 
 }
 
 
-
-
-function checkContentType(ctype){
-	ctype = ctype || ""
-	return (ctype.toLowerCase().split(";")[0] == "text/html");
+function checkContentType(ctype) {
+    ctype = ctype || ""
+    return (ctype.toLowerCase().split(";")[0] == "text/html");
 };
 
-function assertContentTypeHtml(response){
-	if(!checkContentType(response.contentType)){
-		printStatus("error", "contentType", "content type is " + response.contentType); // escape response.contentType???
-		phantom.exit(0);
-	}
+function assertContentTypeHtml(response) {
+    if (!checkContentType(response.contentType)) {
+        printStatus("error", "contentType", "content type is " + response.contentType); // escape response.contentType???
+        phantom.exit(0);
+    }
 }
 
-function getCookies(headers, url){
-	var a, b, c, ret = [];
-	var purl = document.createElement('a');
-	purl.href = url;
-	var domain = purl.hostname;
+function verifyUserScript(script) {
+    if (!script) return true;
+    try {
+        eval("var x = " + script.trim() + ";");
+    } catch (e) {
+        return "" + e;
+    }
 
-	for(a = 0; a < headers.length; a++){
-		if(headers[a].name.toLowerCase() == "set-cookie"){
-			var cookies = headers[a].value.split("\n");	 // phantomjs stores multiple cookies in this way ..
-			for(b = 0; b < cookies.length; b++){
-				var ck = cookies[b].split(/; */);
-				var cookie = {domain: domain, path: "/", secure: false, httponly:false};
-				for(c = 0; c < ck.length; c++){
-					var kv = ck[c].split("=");
-					if(c == 0){
-						cookie.name = kv[0];
-						cookie.value = decodeURIComponent(kv[1]);
-						continue;
-					}
-					switch(kv[0].toLowerCase()){
-						case "expires":
-							if(!("expires" in cookie))
-								cookie.expires = parseInt((new Date(kv[1])).getTime() / 1000);
-							break;
-						case "max-age":
-							cookie.expires = parseInt(((new Date()).getTime() / 1000) + parseInt(kv[1]));
-							break;
-						case "domain":
-						case "path":
-							cookie[kv[0]] = kv[1];
-							break;
-						case "httponly":
-						case "secure":
-							cookie[kv[0]] = true;
-							break;
-					}
-				}
-				ret.push(cookie);
-			}
-		}
-	}
-	return ret;
-};
-
-
-
-function verifyUserScript(script){
-	if(!script) return true;
-	try{
-		eval("var x = " + script.trim() + ";");
-	}catch(e){
-		return "" + e;
-	}
-
-	return true;
+    return true;
 }
 

--- a/core/lib/database.py
+++ b/core/lib/database.py
@@ -86,9 +86,9 @@ class Database:
         :param user_agent: user defined agent
         :return: the id of the crawl
         """
-        values = [htcap_version, target, start_date, None, commandline, user_agent, None]
+        values = [htcap_version, target, start_date, commandline, user_agent]
 
-        insert_query = "INSERT INTO crawl_info VALUES (?,?,?,?,?,?,?)"
+        insert_query = "INSERT INTO crawl_info (htcap_version,target,start_date,commandline,user_agent) VALUES (?,?,?,?,?)"
 
         self.connect()
         cur = self.conn.cursor()

--- a/core/lib/database.py
+++ b/core/lib/database.py
@@ -74,11 +74,12 @@ class Database:
         self.close()
 
     def save_crawl_info(self,
-                        htcap_version="NULL", target="NULL", start_date="NULL", commandline="NULL",
-                        user_agent="NULL"):
+                        htcap_version=None, target=None, start_date=None, commandline=None,
+                        user_agent=None, start_cookies=[]):
         """
         connect, save the provided crawl info then close the connection
     
+        :param start_cookies: start cookies provided by the user
         :param htcap_version: version of the running instance of htcap
         :param target: start url of the crawl
         :param start_date: start date of the crawl
@@ -86,9 +87,10 @@ class Database:
         :param user_agent: user defined agent
         :return: the id of the crawl
         """
-        values = [htcap_version, target, start_date, commandline, user_agent]
+        values = [htcap_version, target, start_date, commandline, user_agent,
+                  json.dumps([c.get_dict() for c in start_cookies])]
 
-        insert_query = "INSERT INTO crawl_info (htcap_version,target,start_date,commandline,user_agent) VALUES (?,?,?,?,?)"
+        insert_query = "INSERT INTO crawl_info (htcap_version,target,start_date,commandline,user_agent,start_cookies) VALUES (?,?,?,?,?,?)"
 
         self.connect()
         cur = self.conn.cursor()
@@ -100,18 +102,20 @@ class Database:
 
         return crawl_id
 
-    def update_crawl_info(self, crawl_id, crawl_end_date, random_seed):
+    def update_crawl_info(self, crawl_id, crawl_end_date, random_seed, end_cookies):
         """
         connect, save the end date then close the connection
         :param crawl_id: 
         :param crawl_end_date: 
         :param random_seed:
+        :param end_cookies:
         """
-        update_crawl_query = "UPDATE crawl_info SET end_date = ?, random_seed = ? WHERE rowid = ?"
+        update_crawl_query = "UPDATE crawl_info SET end_date = ?, random_seed = ?, end_cookies = ? WHERE rowid = ?"
 
         self.connect()
         cur = self.conn.cursor()
-        cur.execute(update_crawl_query, [crawl_end_date, random_seed, crawl_id])
+        cur.execute(update_crawl_query,
+                    [crawl_end_date, random_seed, json.dumps([c.get_dict() for c in end_cookies]), crawl_id])
         self.commit()
         self.close()
 
@@ -330,21 +334,21 @@ class Database:
 
         return requests
 
-    def retrieve_crawl_options(self, crawl_id):
+    def retrieve_crawl_info(self, crawl_id):
         """
-        return the options stored for the given crawl
+        return the information stored for the given crawl
         :param crawl_id: 
         :return: random_seed
         """
-        query = "SELECT random_seed FROM crawl_info WHERE rowid=?"
+        query = "SELECT random_seed, end_cookies FROM crawl_info WHERE rowid=?"
 
         self.connect()
         cur = self.conn.cursor()
         cur.execute(query, [crawl_id])
-        options = cur.fetchone()
+        result = cur.fetchone()
         self.close()
 
-        return options["random_seed"]
+        return result["random_seed"], result["end_cookies"]
 
 
 _CREATE_CRAWL_INFO_TABLE_QUERY = """
@@ -355,7 +359,9 @@ CREATE TABLE crawl_info (
     end_date INTEGER,
     commandline TEXT,
     user_agent TEXT,
-    random_seed TEXT
+    random_seed TEXT,
+    start_cookies TEXT,
+    end_cookies TEXT
 )
 """
 

--- a/tests/lib_tests/database_tests.py
+++ b/tests/lib_tests/database_tests.py
@@ -96,9 +96,9 @@ class DatabaseTest(DatabaseTestCase):
         self.assertEqual(
             self.cursor_mock.execute.call_args_list[0],
             call(
-                "INSERT INTO crawl_info VALUES (?,?,?,?,?,?,?)",
-                ["42.0", "my target", "my start date", None,
-                 "my commandline", "some user agent", None]))
+                "INSERT INTO crawl_info (htcap_version,target,start_date,commandline,user_agent) VALUES (?,?,?,?,?)",
+                ["42.0", "my target", "my start date",
+                 "my commandline", "some user agent"]))
         self.assertEqual(
             self.cursor_mock.execute.call_args_list[1],
             call(


### PR DESCRIPTION
Changes:
- Storing in db the starting cookies (`crawl_info.starting_cookies`) and the cookies set at the end of the crawl (`crawl_info.end_cookies`) 
- using the last set cookies if no cookie provided
- fix the printCookies in the JS probe (it was using the http header instead of the browser cookie jar) to get all the cookies set during the last session
- auto cleanup indentation in the js files.